### PR TITLE
Fix deprecated calls for KillAdvancement, remove redundant allocations

### DIFF
--- a/src/main/java/tv/galaxe/galaxesmp/advancements/KillAdvancement.java
+++ b/src/main/java/tv/galaxe/galaxesmp/advancements/KillAdvancement.java
@@ -1,6 +1,7 @@
-/* (C)2022 GalaxeTV */
+/* (C)2022-2023 GalaxeTV */
 package tv.galaxe.galaxesmp.advancements;
 
+import java.util.Objects;
 import java.util.concurrent.ThreadLocalRandom;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.sound.Sound;
@@ -41,7 +42,8 @@ public class KillAdvancement implements Listener {
    */
   private TextComponent itemMetaCheck(ItemStack item) {
     if (item.hasItemMeta() && item.getItemMeta().hasDisplayName()) {
-      return Component.text("a " + item.getItemMeta().getDisplayName())
+      return Component.text("a ")
+          .append(Objects.requireNonNull(item.getItemMeta().displayName()))
           .hoverEvent(item.asHoverEvent());
     } else if (item.getType() == Material.AIR) {
       return Component.text("Fists");

--- a/src/main/java/tv/galaxe/galaxesmp/commands/TwitchCmd.java
+++ b/src/main/java/tv/galaxe/galaxesmp/commands/TwitchCmd.java
@@ -1,4 +1,4 @@
-/* (C)2022 GalaxeTV */
+/* (C)2022-2023 GalaxeTV */
 package tv.galaxe.galaxesmp.commands;
 
 import net.kyori.adventure.text.Component;
@@ -15,7 +15,7 @@ import tv.galaxe.galaxesmp.util.TwitchIntegration;
 
 public class TwitchCmd implements CommandExecutor {
 
-  private GalaxeSMP plugin = null;
+  private GalaxeSMP plugin;
 
   /**
    * Plugin instance from the server

--- a/src/main/java/tv/galaxe/galaxesmp/util/TwitchIntegration.java
+++ b/src/main/java/tv/galaxe/galaxesmp/util/TwitchIntegration.java
@@ -1,4 +1,4 @@
-/* (C)2022 GalaxeTV */
+/* (C)2022-2023 GalaxeTV */
 package tv.galaxe.galaxesmp.util;
 
 import com.github.philippheuer.events4j.simple.domain.EventSubscriber;
@@ -14,7 +14,7 @@ import org.bukkit.entity.Player;
 import tv.galaxe.galaxesmp.GalaxeSMP;
 
 public class TwitchIntegration {
-  private GalaxeSMP plugin = null;
+  private GalaxeSMP plugin;
   private static boolean isLive = false;
 
   /**


### PR DESCRIPTION
### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "Closes #nnnn" for each issue. 
-->

This PR fixes #7.

### Details

<!--
    If you are submitting a bug fix, you should remove the "Proposed fix:" section.
    If you are submitting a new feature, you should remove the "Proposed feature:" section.
-->

**Proposed fix:**
<!-- Type a description of your proposed fix below this line. -->
`KillAdvancement` had a deprecated call that is set for removal soon. This now uses the correct calls to get item display name.

Removed redundant and unused assignments for `TwitchCmd` and `TwitchIntegration`. This threw warnings with Qodana and should now be rectified.

Updates copyright year.

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: Linux

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 17

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [x] Most recent GeyserMC version (2.XX.Y)

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

n/a