### PR TITLE
Modularize permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,6 @@ Steps:
 
 The reason for shadowing is an issue with the [Twitch4J](https://github.com/twitch4j/twitch4j) library used for Twitch integration. This results in a larger plugin however it remains similarly functional.
 
-## Dependencies for your Minecraft Server
-
-This plugin requires the following plugins to be installed on your server:
-
-- LuckPerms
-
 ## Code conventions/quality gates
 
 This repository currently has a couple of checks in place to ensure code quality. These are:

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ repositories {
 dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.0'
     compileOnly 'io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT'
-    compileOnly 'net.luckperms:api:5.4'
     implementation 'com.github.twitch4j:twitch4j:1.13.0'
 }
 

--- a/src/main/java/tv/galaxe/galaxesmp/GalaxeSMP.java
+++ b/src/main/java/tv/galaxe/galaxesmp/GalaxeSMP.java
@@ -1,11 +1,10 @@
-/* (C)2022 GalaxeTV */
+/* (C)2022-2023 GalaxeTV */
 package tv.galaxe.galaxesmp;
 
 import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.ITwitchClient;
 import com.github.twitch4j.TwitchClientBuilder;
 import java.util.Objects;
-import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import tv.galaxe.galaxesmp.advancements.*;

--- a/src/main/java/tv/galaxe/galaxesmp/GalaxeSMP.java
+++ b/src/main/java/tv/galaxe/galaxesmp/GalaxeSMP.java
@@ -5,10 +5,8 @@ import com.github.philippheuer.events4j.simple.SimpleEventHandler;
 import com.github.twitch4j.ITwitchClient;
 import com.github.twitch4j.TwitchClientBuilder;
 import java.util.Objects;
-import net.luckperms.api.LuckPerms;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 import tv.galaxe.galaxesmp.advancements.*;
 import tv.galaxe.galaxesmp.commands.*;
@@ -18,7 +16,6 @@ public final class GalaxeSMP extends JavaPlugin {
 
   private static GalaxeSMP instance;
   private ITwitchClient twitchClient;
-  private RegisteredServiceProvider<LuckPerms> luckPerms;
 
   /**
    * Gets the plugin instance to be used
@@ -38,15 +35,6 @@ public final class GalaxeSMP extends JavaPlugin {
     return this.twitchClient;
   }
 
-  /**
-   * Gets the LuckPerms API
-   *
-   * @return LuckPerms API
-   */
-  public LuckPerms getLuckPerms() {
-    return this.luckPerms.getProvider();
-  }
-
   @Override
   public void onEnable() {
     instance = this;
@@ -54,9 +42,6 @@ public final class GalaxeSMP extends JavaPlugin {
     // Get config
     this.saveDefaultConfig();
     FileConfiguration config = getConfig();
-
-    // Register LuckPerms
-    luckPerms = Bukkit.getServicesManager().getRegistration(LuckPerms.class);
 
     // Build TwitchClient
     twitchClient =

--- a/src/main/java/tv/galaxe/galaxesmp/advancements/KillAdvancement.java
+++ b/src/main/java/tv/galaxe/galaxesmp/advancements/KillAdvancement.java
@@ -77,7 +77,7 @@ public class KillAdvancement implements Listener {
     }
 
     // Check if player killed a staff member and if the killer is not null
-    if (killer != null && killer != player && player.hasPermission("group.admin")) {
+    if (killer != null && killer != player && player.hasPermission("galaxesmp.staff")) {
       // Set names of killer and killed player
       final Component killerName = killer.playerListName();
       final Component playerName = player.playerListName();

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,8 +4,6 @@ main: tv.galaxe.galaxesmp.GalaxeSMP
 api-version: 1.19
 prefix: GalaxeSMP
 authors: [ garrettsummerfi3ld ]
-depend:
-  - LuckPerms
 description: A general plugin to help manage the GalaxeSMP
 website: https://github.com/GalaxeTV/GalaxeSMP-Plugin
 commands:
@@ -13,6 +11,12 @@ commands:
     description: Toggles item frame visibility
     usage: /invisibleitemframe
     aliases: [invisframe, iframe, ifr, invframe]
+    default: true
   twitch:
     description: Shows the Galaxe Twitch channel
     usage: /twitch
+    default: true
+permissions:
+  galaxesmp.staff:
+    description: Sets staff permissions for KillAdvancement
+    default: op


### PR DESCRIPTION
### Information

This PR modularizes permission nodes away from LuckPerms.

### Details

**Proposed feature:**

Permission nodes tied to LuckPerms is not a good idea if there is a switch from permissions manager to another permissions manager, this makes the permissions internal and not to be reached outside of the plugin.

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: N/a

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: N/a

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] Most recent GeyserMC version (2.XX.Y)

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->

N/a