### PR TITLE
Update Gradle workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,11 +32,11 @@ jobs:
     - name: Change Gradle Permissions
       run: chmod +x gradlew
     - name: Build with Gradle
-      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
+      uses: gradle/gradle-build-action@v2.3.3
       with:
         arguments: build
     - name: Shadow Jar
-      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
+      uses: gradle/gradle-build-action@v2.3.3
       with:
         arguments: shadowJar
     - name: Upload Artifact


### PR DESCRIPTION
Updates Gradle workflow to use latest stable tags.

### Information

Uses updated Gradle build actions.

### Details

**Proposed fix:**
<!-- Type a description of your proposed fix below this line. -->
Actions were using an old version of the Gradle Build Action, this now uses the latest stable tags from Gradle.

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: N/a

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: N/a

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] ~Most recent Paper version (1.XX.Y, git-Paper-BUILD)~
- [ ] ~Most recent GeyserMC version (2.XX.Y)~

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
N/a