### PR TITLE
Add Gradle Wrapper check for CI jobs

### DIFF
--- a/.github/workflows/gradle-validation.yml
+++ b/.github/workflows/gradle-validation.yml
@@ -1,0 +1,19 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Gradle Validation
+
+# Controls when the action will run. 
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  validation:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    - uses: actions/checkout@v3
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    - name: Gradle Wrapper Validation
+      uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/gradle-validation.yml
+++ b/.github/workflows/gradle-validation.yml
@@ -1,19 +1,10 @@
-# This is a basic workflow to help you get started with Actions
-
-name: Gradle Validation
-
-# Controls when the action will run. 
+name: "Validate Gradle Wrapper"
 on: [push, pull_request]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
   validation:
-    # The type of runner that the job will run on
+    name: "Validation"
     runs-on: ubuntu-latest
-
-    - uses: actions/checkout@v3
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    - name: Gradle Wrapper Validation
-      uses: gradle/wrapper-validation-action@v1
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gradle/wrapper-validation-action@v1


### PR DESCRIPTION
### Information

Adds a Gradle wrapper check to ensure valid Gradle wrapper JARs are valid and do not contain malicious code.

In response to a [Gradle blog post](https://blog.gradle.org/wrapper-attack-report).

### Details

**Proposed feature:**
<!-- Type a description of your proposed feature below this line. -->

Adds a check for Gradle wrappers to be validated and deemed not malicious to build code with.

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: N/a

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: N/a

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] ~Most recent Paper version (1.XX.Y, git-Paper-BUILD)~
- [ ] ~Most recent GeyserMC version (2.XX.Y)~

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
N/a