### PR TITLE
Add silk touch ability to budding amethyst blocks

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,5 +18,3 @@ jobs:
         uses: actions/checkout@v3
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v3
-      - name: Gradle Dependency Submission
-        uses: mikepenz/gradle-dependency-submission@v0.8.6

--- a/src/main/java/tv/galaxe/galaxesmp/GalaxeSMP.java
+++ b/src/main/java/tv/galaxe/galaxesmp/GalaxeSMP.java
@@ -9,6 +9,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import tv.galaxe.galaxesmp.advancements.*;
 import tv.galaxe.galaxesmp.commands.*;
+import tv.galaxe.galaxesmp.events.SilkTouchAmethyst;
 import tv.galaxe.galaxesmp.util.*;
 
 public final class GalaxeSMP extends JavaPlugin {
@@ -63,6 +64,7 @@ public final class GalaxeSMP extends JavaPlugin {
 
     // Register server events
     getServer().getPluginManager().registerEvents(new KillAdvancement(this), this);
+    getServer().getPluginManager().registerEvents(new SilkTouchAmethyst(this), this);
 
     twitchClient
         .getEventManager()

--- a/src/main/java/tv/galaxe/galaxesmp/events/SilkTouchAmethyst.java
+++ b/src/main/java/tv/galaxe/galaxesmp/events/SilkTouchAmethyst.java
@@ -1,0 +1,47 @@
+/* (C)2023 GalaxeTV */
+package tv.galaxe.galaxesmp.events;
+
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+import tv.galaxe.galaxesmp.GalaxeSMP;
+
+public class SilkTouchAmethyst implements Listener {
+
+  private final GalaxeSMP plugin;
+
+  /**
+   * Plugin instance from the server
+   *
+   * @param plugin Sets current instance of the plugin
+   */
+  public SilkTouchAmethyst(GalaxeSMP plugin) {
+    this.plugin = plugin;
+  }
+
+  /**
+   * This event is called when a player breaks a block.
+   *
+   * @param event The event that was called.
+   */
+  @EventHandler
+  public void onBlockBreak(BlockBreakEvent event) {
+    if (event.getBlock().getType() == Material.BUDDING_AMETHYST) {
+      if (event
+          .getPlayer()
+          .getInventory()
+          .getItemInMainHand()
+          .containsEnchantment(Enchantment.SILK_TOUCH)) {
+        event.setDropItems(false);
+        event
+            .getBlock()
+            .getWorld()
+            .dropItemNaturally(
+                event.getBlock().getLocation(), new ItemStack(Material.BUDDING_AMETHYST, 1));
+      }
+    }
+  }
+}


### PR DESCRIPTION

### Information

<!--
    Replace #nnnn with the number of the original issue. If this PR fixes
    multiple issues, you should repeat the phrase "Closes #nnnn" for each issue. 
-->

This block is not able to be dropped normally within Minecraft. This event now makes this possible for those with any silk-touch pickaxe to get that item.


### Details

<!--
    If you are submitting a bug fix, you should remove the "Proposed fix:" section.
    If you are submitting a new feature, you should remove the "Proposed feature:" section.
-->

**Proposed feature:**

Make any broken amethyst drop normally.

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: Ubuntu 22.04.2 LTS -- Staging Server

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: 17

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [x] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [x] Most recent GeyserMC version (2.XX.Y)

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Staging server has a live version of this feature already.