### PR TITLE
Update Gradle versioning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,13 @@ plugins {
     id 'java'
     id 'com.diffplug.spotless' version '6.18.0'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.palantir.git-version' version '3.0.0'
 }
 
+def details = versionDetails()
+
 group = 'tv.galaxe'
-version = '2.0-SNAPSHOT'
+version = details.lastTag + (details.commitDistance > 0 ? "-SNAPSHOT" : "") + (details.branchName != null ? "+" + details.branchName.replace("/", "-") : "") + "@" + details.gitHash
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
### Information

Added Git information to build and plugin versions.

### Details

**Proposed feature:**
<!-- Type a description of your proposed feature below this line. -->
This adds Git versioning to the built binaries and potentially versioning inside the Minecraft server

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: N/a

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: Java 17

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- [ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)
- [ ] Most recent GeyserMC version (2.XX.Y)

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
