### PR TITLE
Add GitHub Dependency Graph support

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Change Gradle Permissions
       run: chmod +x gradlew
     - name: Setup Gradle to generate and submit dependency graphs
-      uses: gradle/gradle-build-action@dependency-graph
+      uses: gradle/gradle-build-action@v2.6.0
       with:
         dependency-graph: generate-and-submit
     - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,10 @@ jobs:
         distribution: 'temurin'
     - name: Change Gradle Permissions
       run: chmod +x gradlew
+    - name: Setup Gradle to generate and submit dependency graphs
+      uses: gradle/gradle-build-action@dependency-graph
+      with:
+        dependency-graph: generate-and-submit
     - name: Build with Gradle
       uses: gradle/gradle-build-action@v2.6.0
       with:


### PR DESCRIPTION
### Information

Adds new Dependency Graph accessibility for project dependencies.

### Details

**Proposed feature:**
<!-- Type a description of your proposed feature below this line. -->

Enables the Gradle action to build and submit dependencies to the GitHub API for reporting total project dependencies and vulnerability reporting.

**Environments tested:**

<!-- Type the OS you have used below. -->
OS: N/a

<!-- Type the JDK version (from java -version) you have used below. -->
Java version: N/a

<!--
    Put an "x" inside the boxes for the server software you have tested this 
    bug fix on. If this feature does not apply to a server, strike through the server software using ~~strikethrough~~. If you have tested on other
    environments, add a new line with relevant details.
-->
- ~~[ ] Most recent Paper version (1.XX.Y, git-Paper-BUILD)~~
- ~~[ ] Most recent GeyserMC version (2.XX.Y)~~

**Demonstration:**
<!--
    Below this block, include screenshots/log snippets from before and after as
    necessary. If you have created or used a test case plugin, please link to a
    download of the plugin, source code and exact version used where possible.
-->
Not applicable.